### PR TITLE
proposal: add backstage policy reporter plugin

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -180,6 +180,7 @@ For this reason, maintainers can be specific to one (or more) area of the code b
 - [Kyverno Playground](https://github.com/kyverno/playground)
 - [Kyverno Policy Reporter](https://github.com/kyverno/policy-reporter)
 - [Kyverno Reports Server](https://github.com/kyverno/reports-server)
+- [Kyverno Backstage Policy Reporter](https://github.com/VELUX/backstage-policy-reporter-plugin)
 
 ### Projects areas
 
@@ -202,6 +203,8 @@ This list is not exhaustive and is subject to modifications as the project evolv
 | Kyverno Policy Reporter | `backend` | Kyverno Policy Reporter backend |
 | Kyverno Policy Reporter | `helm-chart` | Kyverno Policy Reporter Helm chart |
 | Kyverno Reports Server | -- | Kyverno Reports Server project |
+| Kyverno Backstage Policy Reporter | `frontend` | Kyverno Backstage Policy Reporter frontend |
+| Kyverno Backstage Policy Reporter | `backend` | Kyverno Backstage Policy Reporter backend |
 
 ## Conflict Resolutions
 


### PR DESCRIPTION
This PR initiates the vote to add the [Kyverno Policy Reporter Backstage Plugin](https://github.com/VELUX/backstage-policy-reporter-plugin) to Kyverno org as discussed in [maintainers meetings](https://docs.google.com/document/d/1I_GWsz32gLw8sQyuu_Wv0-WQrtRLjn9FuX2KGNkvUY4/edit?tab=t.0) on 11/26/2024 and 12/10/2024.