### PR TITLE
Apply for Kyverno Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,7 @@ https://github.com/orgs/kyverno/teams/kyverno-maintainers
 | Mariam Fahmy             | [@MariamFahmy98](https://github.com/MariamFahmy98)     | Nirmata                   |          
 | Frank Jogeleit           | [@fjogeleit](https://github.com/fjogeleit)             | Nirmata                   |          
 | Liang Deng               | [@YTGhost](https://github.com/YTGhost)                 | Kuaishou Technology       |
+| Jonas Beck               | [@Jonas-Beck](https://github.com/Jonas-Beck)           | VELUX                     |
 
 ## Kyverno JSON Maintainers
 


### PR DESCRIPTION
# Description

This PR adds myself as a Kyverno maintainer based on my contributions to the project, particularly the Backstage Policy Reporter plugin, following the recent changes to the project governance in #40.

I initially created this plugin while at VELUX, where I currently work, before it was added to the Kyverno project, and I have continued to maintain and develop new features for it since its been added.

# Contributions

I have made several contributions to Kyverno, including:

**Feature Enhancements**
* Initial contribution that moved the Backstage Policy Reporter plugin code from private VELUX repository to the Kyverno project (https://github.com/kyverno/backstage-policy-reporter-plugin/commit/be855df0d59ff87db22da75c07c74763ab43699f)
* Improved support for additional source engines by providing components for custom sources (https://github.com/kyverno/backstage-policy-reporter-plugin/pull/34)
* Setup repository to use Backstage yarn plugin and yarn install GitHub action to improve workflow (https://github.com/kyverno/backstage-policy-reporter-plugin/pull/28)

**Infrastructure Improvements**
* Maintained dependencies by keeping all Backstage plugins up to date with the latest Backstage versions for each release (https://github.com/kyverno/backstage-policy-reporter-plugin/pull/12, https://github.com/kyverno/backstage-policy-reporter-plugin/pull/19)

# **Project Ownership**
I am also one of the current maintainers and owners of the Policy Reporter Backstage plugin, which enhances Kyverno's integration with the Backstage internal developer portal.
