### PR TITLE
chore: document security triage process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,8 @@ The security response team is responsible for triaging and coordinating fixes fo
 
 All team members are subscribed to `kyverno-security@googlegroups.com`. Reports sent to that address reach the full team simultaneously.
 
+When a report is received, one team member acts as the coordinator: they acknowledge the report, assess severity, and route the issue to the maintainer best placed to fix it based on the affected component. There is no fixed rotation; the coordinator for a given report is whoever picks it up first from the shared inbox.
+
 ## Security bulletins
 
 For information regarding the security of this project please join our [Slack channel](https://slack.k8s.io/#kyverno).


### PR DESCRIPTION
Ref https://github.com/kyverno/kyverno/issues/15473.

Adds one sentence to the Security Response Team section describing how triage works in practice: one team member acts as coordinator, acknowledges the report, and routes it to the right maintainer based on the affected component. There is no fixed rotation — whoever picks up the report first from the shared inbox coordinates it.

This closes the last open item (item 12) from the CNCF TOC technical review.